### PR TITLE
Feature: Add option to display course short name in header

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -56,6 +56,37 @@ class core_renderer extends \theme_boost\output\core_renderer {
     }
 
     /**
+     * Get the full header of the page.
+     *
+     * @return string HTML to display the main header of the page
+     */
+    public function full_header() {
+        global $COURSE;
+        
+        // Check if we should use course short name in header.
+        $useshortname = get_config('theme_academi', 'useshortnameinheader');
+        
+        if ($useshortname && $this->page->context->contextlevel == CONTEXT_COURSE && $COURSE->id != SITEID) {
+            // Store the original page heading.
+            $originalheading = $this->page->heading;
+            
+            // Set the page heading to the course short name.
+            $this->page->set_heading(format_string($COURSE->shortname, true, ['context' => $this->page->context]));
+            
+            // Get the header HTML.
+            $header = parent::full_header();
+            
+            // Restore the original heading.
+            $this->page->set_heading($originalheading);
+            
+            return $header;
+        }
+        
+        // Use default behavior.
+        return parent::full_header();
+    }
+
+    /**
      * Footer info links.
      * @return string
      */

--- a/lang/ar/theme_academi.php
+++ b/lang/ar/theme_academi.php
@@ -57,6 +57,8 @@ $string['container'] = 'حاوية';
 $string['content'] = 'محتوى';
 $string['copyright_default'] = 'حقوق النشر والنسخ؛ 2017 - تم تطويره بواسطة <a href="http://lmsace.com">LMSACE.com</a>. مدعوم من <a href="https://moodle.org">Moodle</a>';
 $string['copyright_footer'] = '';
+$string['courseheading'] = 'الدورة';
+$string['courseheaderheading'] = 'رأس الدورة';
 $string['custom'] = 'مخصص';
 $string['customcss'] = 'مخصصCSS';
 $string['customcssdesc'] = 'مهما كانت قواعد CSS التي تضيفها إلى منطقة النص هذه ، فسوف تنعكس في كل صفحة ، مما يسهل تخصيص هذا المظهر.';
@@ -257,6 +259,8 @@ $string['toggleslideshowdesc'] = 'اختر ما إذا كنت تريد إخفا�
 $string['topCenter'] = 'مركز أعلى';
 $string['topLeft'] = 'أعلى اليسار';
 $string['topRight'] = 'اعلى اليمين';
+$string['useshortnameinheader'] = 'إظهار الاسم المختصر للدورة في الرأس';
+$string['useshortnameinheader_desc'] = 'عند التمكين، سيتم عرض الاسم المختصر للدورة في الرأس بدلاً من الاسم الكامل للدورة. هذا مفيد عندما تأتي بيانات الدورة من أنظمة خارجية حيث يحتوي حقل الاسم المختصر على نص عرض أكثر ملاءمة.';
 $string['url'] = 'URL';
 $string['urldesc'] = 'أدخل عنوان URL لتعيين الرابط لعنوان ميزة هذا الموقع {$a->block}';
 $string['viewallcourses'] = 'عرض جميع الدورات';

--- a/lang/en/theme_academi.php
+++ b/lang/en/theme_academi.php
@@ -58,6 +58,8 @@ $string['content'] = 'Content';
 $string['content_desc'] = 'To set the content for the this block, enter the block content as plain text or use the "lang" prefix followed by the appropriate "language_key" for multi-lingual support. You can find the theme language keys for multi-lingual support in the "/theme/academi/lang/en/theme_academi.php" file.';
 $string['copyright_default'] = 'Copyright &copy; 2017 - Developed by <a href="http://lmsace.com">LMSACE.com</a>. Powered by <a href="https://moodle.org">Moodle</a>';
 $string['copyright_footer'] = 'Copyright';
+$string['courseheading'] = 'Course';
+$string['courseheaderheading'] = 'Course Header';
 $string['custom'] = "Custom";
 $string['customcss'] = 'Custom CSS';
 $string['customcssdesc'] = 'Whatever CSS rules you add to this textarea will be reflected in every page, making for easier customization of this theme.';
@@ -260,6 +262,8 @@ $string['toggleslideshowdesc'] = 'Choose if you wish to hide or show the slide s
 $string['topCenter'] = 'TopCenter';
 $string['topLeft'] = 'TopLeft';
 $string['topRight'] = 'TopRight';
+$string['useshortnameinheader'] = 'Show course short name in header';
+$string['useshortnameinheader_desc'] = 'When enabled, the course short name will be displayed in the header instead of the full course name. This is useful when course data comes from external systems where the short name field contains more appropriate display text.';
 $string['url'] = 'URL';
 $string['urldesc'] = 'Enter the URL to set the link for the title of this site feature {$a->block}';
 $string['viewallcourses'] = 'View all courses';

--- a/settings.php
+++ b/settings.php
@@ -40,6 +40,8 @@ if ($ADMIN->fulltree) {
     include(dirname(__FILE__) . '/settings/marketingspot.php');
     // Jumbotron Settings.
     include(dirname(__FILE__) . '/settings/jumbotron.php');
+    // Course Settings.
+    include(dirname(__FILE__) . '/settings/course.php');
     // Footer Settings.
     include(dirname(__FILE__) . '/settings/footer.php');
 }

--- a/settings/course.php
+++ b/settings/course.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Admin settings configuration for course section
+ *
+ * @package    theme_academi
+ * @copyright  2023 onwards LMSACE Dev Team (http://www.lmsace.com)
+ * @author    LMSACE Dev Team
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+// Course section.
+$temp = new admin_settingpage('theme_academi_course', get_string('courseheading', 'theme_academi'));
+
+// Create course header heading.
+$name = 'theme_academi/courseheaderheading';
+$title = get_string('courseheaderheading', 'theme_academi');
+$setting = new admin_setting_heading($name, $title, null);
+$temp->add($setting);
+
+// Setting: Use course short name in header.
+$name = 'theme_academi/useshortnameinheader';
+$title = get_string('useshortnameinheader', 'theme_academi');
+$description = get_string('useshortnameinheader_desc', 'theme_academi');
+$default = NO;
+$choices = [
+    YES => get_string('yes'),
+    NO => get_string('no'),
+];
+$setting = new admin_setting_configselect($name, $title, $description, $default, $choices);
+$temp->add($setting);
+
+$settings->add($temp);


### PR DESCRIPTION
This pull request implements a new theme setting that allows administrators to choose whether course headers display the full course name (default behavior) or the course short name.

# Background & Use Case
This feature addresses scenarios where course data comes from external systems that may populate the "short name" field with content that's more appropriate for header display than the full course name. While the field is called "short name," external systems sometimes use it for display-friendly course identifiers that may actually be more suitable for headers than the official full course name.

# Changes Made
1. Core Renderer Logic ([core_renderer.php](vscode-file://vscode-app/usr/share/code-insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
- Added new full_header() method that checks the theme setting
- When enabled and on a course page (excluding site home), the page heading is set to the formatted course short name using proper set_heading() method
- Preserves all existing functionality and header features
- Uses proper context formatting for security and consistency
2. Settings Structure
- Created new file: /settings/course.php with course-specific settings following the theme's existing pattern
- Updated: [settings.php](vscode-file://vscode-app/usr/share/code-insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to include the new course settings file
- Added the setting under a "Course Header" section for logical organization
- Uses theme's existing YES/NO constants for consistency
3. Language Support
- English ([theme_academi.php](vscode-file://vscode-app/usr/share/code-insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html)): Added proper labels and descriptions
- Arabic ([theme_academi.php](vscode-file://vscode-app/usr/share/code-insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html)): Added Arabic translations (Note: Arabic strings are AI-generated, so accuracy may need verification by native speakers)