### PR TITLE
Fix deprecated Bootstrap 4 .ml-auto class for Moodle 5.0

### DIFF
--- a/templates/drawers.mustache
+++ b/templates/drawers.mustache
@@ -109,7 +109,7 @@
                         </div>
                     {{/courseindex}}
                     {{#hasblocks}}
-                        <div class="drawer-toggler drawer-right-toggle ml-auto d-print-none">
+                        <div class="drawer-toggler drawer-right-toggle ms-auto d-print-none">
                             <button
                                 class="btn icon-no-margin"
                                 data-toggler="drawers"

--- a/templates/frontpage.mustache
+++ b/templates/frontpage.mustache
@@ -108,7 +108,7 @@
                         </div>
                     {{/courseindex}}
                     {{#hasblocks}}
-                        <div class="drawer-toggler drawer-right-toggle ml-auto d-print-none">
+                        <div class="drawer-toggler drawer-right-toggle ms-auto d-print-none">
                             <button
                                 class="btn icon-no-margin"
                                 data-toggler="drawers"

--- a/templates/navbar.mustache
+++ b/templates/navbar.mustache
@@ -107,7 +107,7 @@
                 </ul>
             {{/themestyleheader}}
 
-        <div id="usernavigation" class="navbar-nav ml-auto">
+        <div id="usernavigation" class="navbar-nav ms-auto">
             {{#langmenu}}
                 {{> theme_boost/language_menu }}
             {{/langmenu}}


### PR DESCRIPTION
## Summary

Moodle 5.0 ships with Bootstrap 5, which renamed margin/padding utility classes from directional (`.ml-*`, `.mr-*`) to logical (`.ms-*`, `.me-*`). The academi theme still uses `.ml-auto` in three templates, causing a **"Deprecated style in use (.ml)"** warning banner on every page.

This PR replaces `.ml-auto` with `.ms-auto` in:
- `templates/drawers.mustache`
- `templates/frontpage.mustache`
- `templates/navbar.mustache`

## Screenshots

Before fix — warning banner visible on every page:

> "Deprecated style in use (.ml)"

## Test plan

- [ ] Install academi theme on Moodle 5.0
- [ ] Verify no "Deprecated style in use" warning appears
- [ ] Verify drawer toggle and user navigation still align correctly (right-aligned)